### PR TITLE
check for stale cluster info before retrying

### DIFF
--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -105,6 +105,7 @@ module Kafka
     # @param partition [Integer]
     # @return [Broker] the broker that's currently leader.
     def get_leader(topic, partition)
+      refresh_metadata_if_necessary!
       connect_to_broker(get_leader_id(topic, partition))
     end
 

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -18,6 +18,38 @@ describe Kafka::Cluster do
       allow(broker).to receive(:disconnect)
     end
 
+    it 'raises NotLeaderForPartition if the current broker is not the leader' do
+      metadata = Kafka::Protocol::MetadataResponse.new(
+        brokers: [
+          Kafka::Protocol::MetadataResponse::BrokerInfo.new(
+            node_id: 42,
+            host: "test1",
+            port: 9092,
+          )
+        ],
+        controller_id: 42,
+        topics: [
+          Kafka::Protocol::MetadataResponse::TopicMetadata.new(
+            topic_name: "greetings",
+            partitions: [
+              Kafka::Protocol::MetadataResponse::PartitionMetadata.new(
+                partition_id: 42,
+                leader: 2,
+
+                partition_error_code: 6, # <-- this is the important bit. NotLeaderForPartition
+              )
+            ]
+          )
+        ]
+      )
+
+      allow(broker).to receive(:fetch_metadata) { metadata }
+
+      expect {
+        cluster.get_leader("greetings", 42)
+      }.to raise_error Kafka::NotLeaderForPartition
+    end
+
     it "raises LeaderNotAvailable if there's no leader for the partition" do
       metadata = Kafka::Protocol::MetadataResponse.new(
         brokers: [
@@ -87,6 +119,42 @@ describe Kafka::Cluster do
       expect {
         cluster.get_leader("greetings", 42)
       }.to raise_exception(Kafka::ConnectionError)
+    end
+
+    context 'meta data is stale' do
+      before do
+        allow(cluster).to receive(:stale) { true }
+      end
+
+      it 'should re fetch metadata' do
+        metadata = Kafka::Protocol::MetadataResponse.new(
+          brokers: [
+            Kafka::Protocol::MetadataResponse::BrokerInfo.new(
+              node_id: 42,
+              host: "test1",
+              port: 9092,
+            )
+          ],
+          controller_id: 42,
+          topics: [
+            Kafka::Protocol::MetadataResponse::TopicMetadata.new(
+              topic_name: "greetings",
+              partitions: [
+                Kafka::Protocol::MetadataResponse::PartitionMetadata.new(
+                  partition_id: 42,
+                  leader: 42,
+                  partition_error_code: 0
+                )
+              ]
+            )
+          ]
+        )
+
+        allow(broker).to receive(:fetch_metadata) { metadata }
+        expect(cluster).to receive(:refresh_metadata!)
+
+        cluster.get_leader("greetings", 42)
+      end
     end
   end
 end


### PR DESCRIPTION
So we keep stale data from the cluster even when we try to reread the leader.

so basically `#get_leader` keeps getting the same error over on NotLeaderForPartition, when leader rebalance happens and we are sending a batch, and it wasn't triggering a reread.