### PR TITLE
Move development dependencies to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,25 @@
 source "https://rubygems.org"
 
 gemspec
+
+group :development, :test do
+  gem "activesupport"
+  gem "bundler", ">= 1.9.5"
+  gem "docker-api"
+  gem "dotenv"
+  gem "pry"
+  gem "rake", "~> 10.0"
+  gem "rspec"
+  gem "rspec-benchmark"
+  gem "snappy"
+  gem "colored"
+  gem "dogstatsd-ruby", ">= 3.0.0", "< 5.0.0"
+  gem "extlz4"
+  gem "gssapi", ">= 1.2.0"
+  gem "rspec_junit_formatter", "0.2.2"
+  gem "rubocop", "~> 0.49.1"
+  gem "ruby-prof"
+  gem "stackprof"
+  gem "statsd-ruby"
+  gem "timecop"
+end

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -26,24 +26,4 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-
-  spec.add_development_dependency "bundler", ">= 1.9.5"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "dotenv"
-  spec.add_development_dependency "docker-api"
-  spec.add_development_dependency "rspec-benchmark"
-  spec.add_development_dependency "activesupport"
-  spec.add_development_dependency "snappy"
-  spec.add_development_dependency "extlz4"
-  spec.add_development_dependency "colored"
-  spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
-  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0", "< 5.0.0"
-  spec.add_development_dependency "statsd-ruby"
-  spec.add_development_dependency "ruby-prof"
-  spec.add_development_dependency "timecop"
-  spec.add_development_dependency "rubocop", "~> 0.49.1"
-  spec.add_development_dependency "gssapi", ">= 1.2.0"
-  spec.add_development_dependency "stackprof"
 end


### PR DESCRIPTION
This PR moves the development dependencies to the Gemfile to solve the issue described in https://github.com/catawiki/cw-metrics-ruby/pull/23