### PR TITLE
async_producer: use shorthand arg forwarding.

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -232,8 +232,8 @@ module Kafka
 
       private
 
-      def produce(*args)
-        @producer.produce(*args)
+      def produce(...)
+        @producer.produce(...)
       rescue BufferOverflow
         deliver_messages
         retry

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/zendesk/ruby-kafka"
   spec.license       = "Apache License Version 2.0"
 
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
This will transparently forward all arguments (args and kw_args).

This fixes the kwarg deprecation warnings for ruby 2.7

Note: the minimum version for the gem is now 2.7.0 to support
 the new shorthand syntax.