### PR TITLE
AsyncProducer: Limit the number of retries & AsyncProducer: make sure threads are running before shutdown

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -93,6 +93,8 @@ module Kafka
 
       # The timer will no-op if the delivery interval is zero.
       @timer = Timer.new(queue: @queue, interval: delivery_interval)
+
+      @thread_mutex = Mutex.new
     end
 
     # Produces a message to the specified topic.
@@ -127,6 +129,8 @@ module Kafka
     # @see Kafka::Producer#deliver_messages
     # @return [nil]
     def deliver_messages
+      ensure_threads_running!
+
       @queue << [:deliver_messages, nil]
 
       nil
@@ -138,6 +142,8 @@ module Kafka
     # @see Kafka::Producer#shutdown
     # @return [nil]
     def shutdown
+      ensure_threads_running!
+
       @timer_thread && @timer_thread.exit
       @queue << [:shutdown, nil]
       @worker_thread && @worker_thread.join
@@ -148,11 +154,20 @@ module Kafka
     private
 
     def ensure_threads_running!
-      @worker_thread = nil unless @worker_thread && @worker_thread.alive?
-      @worker_thread ||= Thread.new { @worker.run }
+      return if worker_thread_alive? && timer_thread_alive?
 
-      @timer_thread = nil unless @timer_thread && @timer_thread.alive?
-      @timer_thread ||= Thread.new { @timer.run }
+      @thread_mutex.synchronize do
+        @worker_thread = Thread.new { @worker.run } unless worker_thread_alive?
+        @timer_thread = Thread.new { @timer.run } unless timer_thread_alive?
+      end
+    end
+
+    def worker_thread_alive?
+      !!@worker_thread && @worker_thread.alive?
+    end
+
+    def timer_thread_alive?
+      !!@timer_thread && @timer_thread.alive?
     end
 
     def buffer_overflow(topic, message)
@@ -241,9 +256,9 @@ module Kafka
         begin
           @producer.produce(value, **kwargs)
         rescue BufferOverflow => e
-        deliver_messages
+          deliver_messages
           if @max_retries == -1
-        retry
+            retry
           end
           if retries < @max_retries
             retries += 1

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -71,7 +71,7 @@ module Kafka
     # @param delivery_interval [Integer] if greater than zero, the number of
     #   seconds between automatic message deliveries.
     #
-    def initialize(sync_producer:, max_queue_size: 1000, delivery_threshold: 0, delivery_interval: 0, instrumenter:, logger:)
+    def initialize(sync_producer:, max_queue_size: 1000, delivery_threshold: 0, delivery_interval: 0, max_retries: -1, retry_backoff: 0, instrumenter:, logger:)
       raise ArgumentError unless max_queue_size > 0
       raise ArgumentError unless delivery_threshold >= 0
       raise ArgumentError unless delivery_interval >= 0
@@ -85,6 +85,8 @@ module Kafka
         queue: @queue,
         producer: sync_producer,
         delivery_threshold: delivery_threshold,
+        max_retries: max_retries,
+        retry_backoff: retry_backoff,
         instrumenter: instrumenter,
         logger: logger,
       )
@@ -179,10 +181,12 @@ module Kafka
     end
 
     class Worker
-      def initialize(queue:, producer:, delivery_threshold:, instrumenter:, logger:)
+      def initialize(queue:, producer:, delivery_threshold:, max_retries: -1, retry_backoff: 0, instrumenter:, logger:)
         @queue = queue
         @producer = producer
         @delivery_threshold = delivery_threshold
+        @max_retries = max_retries
+        @retry_backoff = retry_backoff
         @instrumenter = instrumenter
         @logger = logger
       end
@@ -233,10 +237,23 @@ module Kafka
       private
 
       def produce(value, **kwargs)
-        @producer.produce(value, **kwargs)
-      rescue BufferOverflow
+        retries = 0
+        begin
+          @producer.produce(value, **kwargs)
+        rescue BufferOverflow => e
         deliver_messages
+          if @max_retries == -1
         retry
+          end
+          if retries < @max_retries
+            retries += 1
+            sleep(@retry_backoff**retries)
+            retry
+          else
+            @logger.error("Failed to asynchronously produce messages due to BufferOverflow")
+            @instrumenter.instrument("error.async_producer", { error: e })
+          end
+        end
       end
 
       def deliver_messages

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -71,7 +71,7 @@ module Kafka
     # @param delivery_interval [Integer] if greater than zero, the number of
     #   seconds between automatic message deliveries.
     #
-    def initialize(sync_producer:, max_queue_size: 1000, delivery_threshold: 0, delivery_interval: 0, max_retries: -1, retry_backoff: 0, instrumenter:, logger:)
+    def initialize(sync_producer:, max_queue_size: 1000, delivery_threshold: 0, delivery_interval: 0, max_retries: nil, retry_backoff: 0, instrumenter:, logger:)
       raise ArgumentError unless max_queue_size > 0
       raise ArgumentError unless delivery_threshold >= 0
       raise ArgumentError unless delivery_interval >= 0
@@ -196,7 +196,7 @@ module Kafka
     end
 
     class Worker
-      def initialize(queue:, producer:, delivery_threshold:, max_retries: -1, retry_backoff: 0, instrumenter:, logger:)
+      def initialize(queue:, producer:, delivery_threshold:, max_retries: nil, retry_backoff: 0, instrumenter:, logger:)
         @queue = queue
         @producer = producer
         @delivery_threshold = delivery_threshold
@@ -257,10 +257,9 @@ module Kafka
           @producer.produce(value, **kwargs)
         rescue BufferOverflow => e
           deliver_messages
-          if @max_retries == -1
+          if @max_retries.nil?
             retry
-          end
-          if retries < @max_retries
+          elsif retries < @max_retries
             retries += 1
             sleep(@retry_backoff**retries)
             retry

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -252,7 +252,7 @@ module Kafka
     #
     # @see AsyncProducer
     # @return [AsyncProducer]
-    def async_producer(delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, max_retries: -1, retry_backoff: 0, **options)
+    def async_producer(delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, max_retries: nil, retry_backoff: 0, **options)
       sync_producer = producer(**options)
 
       AsyncProducer.new(

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -252,7 +252,7 @@ module Kafka
     #
     # @see AsyncProducer
     # @return [AsyncProducer]
-    def async_producer(delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, **options)
+    def async_producer(delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, max_retries: -1, retry_backoff: 0, **options)
       sync_producer = producer(**options)
 
       AsyncProducer.new(
@@ -260,6 +260,8 @@ module Kafka
         delivery_interval: delivery_interval,
         delivery_threshold: delivery_threshold,
         max_queue_size: max_queue_size,
+        max_retries: max_retries,
+        retry_backoff: retry_backoff,
         instrumenter: @instrumenter,
         logger: @logger,
       )


### PR DESCRIPTION
* fixes https://github.com/zendesk/ruby-kafka/issues/707 which can happen when no kafka cluster is running example when running tests locally.
* if a worker thread unexpectedly dies with unhandled messages in its queue and then we try to call `shutdown`, those messages won't be handled unless `produce` is called in the future (in which case the worker thread will read the `shutdown` message enqueued here and then exit again). With this change we will restart the worker thread so it can receive the `shutdown` message.

Both changes are backwards compatible.

Tested event production on staging with `cw-finance` and `cw-buyer` producing the currency created event.