### PR TITLE
Consumer group: change logger level to warn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # PATH                                 OWNERS
-*                                      @catawiki/fintech-backend
+*                                      @catawiki/backend-council

--- a/lib/kafka/version.rb
+++ b/lib/kafka/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kafka
-  VERSION = "0.6.16"
+  VERSION = "0.6.17"
 end


### PR DESCRIPTION
* Since these errors are retried, we can change the log level to `warn` instead of `error`. Since there is nothing actionable marking them as errors just results in noise.
* Update codeowners to `backend-council`
* Update gem version to `0.6.17`